### PR TITLE
New: Added whereStartPlugin (fixes #29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ https://github.com/cgkineo/adapt-migrations/blob/master/api/commands.js
 Functions:
 * `describe(description, describeFunction)` Describe a migration
 * `whereContent(description, contentFilterFunction)` Limit when the migration runs, return true/false/throw Error
+* `whereStartPlugin(description, startPluginFilterFunction)` Limit when the migration runs, return true/false/throw Error
 * `whereFromPlugin(description, fromPluginFilterFunction)` Limit when the migration runs, return true/false/throw Error
 * `whereToPlugin(description, toPluginFilterFunction)` Limit when the migration runs, return true/false/throw Error
 * `mutateContent(contentFunction)` Change content, return true/false/throw Error

--- a/api/plugins.js
+++ b/api/plugins.js
@@ -33,6 +33,7 @@ export function updatePlugin (description, config) {
 
       context.fromPlugins.forEach(plugin => {
         if (plugin.name !== config.name) return
+        plugin.startVersion = plugin.version
         plugin.version = config.version
         if (!config.framework) return
         plugin.framework = config.framework

--- a/api/where.js
+++ b/api/where.js
@@ -9,6 +9,24 @@ export function whereContent (description, callback) {
   }, { description, type: 'where' })
 };
 
+export function whereStartPlugin (description, callbackOrConfig) {
+  return deferOrRunWrap(({ fromPlugins }) => {
+    return successStopOrErrorWrap('whereStartPlugin', description, async () => {
+      const isCallback = (typeof callbackOrConfig === 'function')
+      if (isCallback) {
+        const callback = callbackOrConfig
+        return callback(fromPlugins)
+      }
+      const config = callbackOrConfig
+      return fromPlugins.some(plugin => {
+        if (config.name && plugin.name !== config.name) return false
+        if (config.version && !semver.satisfies(plugin.startVersion ?? plugin.version, config.version)) return false
+        return true
+      })
+    })
+  }, { description, type: 'where' })
+};
+
 export function whereFromPlugin (description, callbackOrConfig) {
   return deferOrRunWrap(({ fromPlugins }) => {
     return successStopOrErrorWrap('whereFromPlugin', description, async () => {


### PR DESCRIPTION
fixes #29 

### New
* Added `whereStartPlugin(name, versionMask)`

### Notes
You should be able to 
```js
describe(name, async () => {
  whereStartPlugin(name, version)
})
```
But also 
```js
describe(name, async () => {
  mutateContent(name, async content => {
    if (whereStartPlugin(name, version)) {
      // assume default "" was added
    } else {
      // assume current value is set by user
    }
  })
  checkContent(name, async content => {
    if (whereStartPlugin(name, version)) {
      // assume default "" was added
    } else {
      // assume current value is set by user
    }
  })
}) 
```