### PR TITLE
New: Added getComponents with context

### DIFF
--- a/api/helpers.js
+++ b/api/helpers.js
@@ -5,3 +5,7 @@ export function getConfig (content) {
 export function getCourse(content) {
   return content.find(({ _type }) => _type === 'course');
 }
+
+export function getComponents(content, componentName) {
+  return content.filter(({ _component }) => _component === componentName);
+}

--- a/api/helpers.js
+++ b/api/helpers.js
@@ -1,11 +1,17 @@
-export function getConfig (content) {
-  return content.find(({ _type, __path__ }) => _type === 'config' || __path__.endsWith('config.json'))
+import Task from '../lib/Task.js'
+
+export function getContext() {
+  return Task.stack[Task.stack.length - 1].context;
 }
 
-export function getCourse(content) {
-  return content.find(({ _type }) => _type === 'course');
+export function getConfig () {
+  return getContext().content.find(({ _type, __path__ }) => _type === 'config' || __path__.endsWith('config.json'))
 }
 
-export function getComponents(content, componentName) {
-  return content.filter(({ _component }) => _component === componentName);
+export function getCourse() {
+  return getContext().content.find(({ _type }) => _type === 'course');
+}
+
+export function getComponents(componentName) {
+  return getContext().content.filter(({ _component }) => _component === componentName);
 }

--- a/api/helpers.js
+++ b/api/helpers.js
@@ -1,17 +1,13 @@
 import Task from '../lib/Task.js'
 
-function getContext() {
-  return Task.current.context;
-}
-
 export function getConfig () {
-  return getContext().content.find(({ _type, __path__ }) => _type === 'config' || __path__.endsWith('config.json'))
+  return Task.current.context.content.find(({ _type, __path__ }) => _type === 'config' || __path__.endsWith('config.json'))
 }
 
 export function getCourse() {
-  return getContext().content.find(({ _type }) => _type === 'course');
+  return Task.current.context.content.find(({ _type }) => _type === 'course');
 }
 
 export function getComponents(componentName) {
-  return getContext().content.filter(({ _component }) => _component === componentName);
+  return Task.current.context.content.filter(({ _component }) => _component === componentName);
 }

--- a/api/helpers.js
+++ b/api/helpers.js
@@ -1,7 +1,7 @@
 import Task from '../lib/Task.js'
 
 function getContext() {
-  return Task.stack[Task.stack.length - 1].context;
+  return Task.current.context;
 }
 
 export function getConfig () {

--- a/api/helpers.js
+++ b/api/helpers.js
@@ -1,13 +1,17 @@
 import Task from '../lib/Task.js'
 
+function getContent() {
+  return Task.current.context.content;
+}
+
 export function getConfig () {
-  return Task.current.context.content.find(({ _type, __path__ }) => _type === 'config' || __path__.endsWith('config.json'))
+  return getContent().find(({ _type, __path__ }) => _type === 'config' || __path__.endsWith('config.json'))
 }
 
 export function getCourse() {
-  return Task.current.context.content.find(({ _type }) => _type === 'course');
+  return getContent().find(({ _type }) => _type === 'course');
 }
 
 export function getComponents(componentName) {
-  return Task.current.context.content.filter(({ _component }) => _component === componentName);
+  return getContent().filter(({ _component }) => _component === componentName);
 }

--- a/api/helpers.js
+++ b/api/helpers.js
@@ -1,6 +1,6 @@
 import Task from '../lib/Task.js'
 
-export function getContext() {
+function getContext() {
   return Task.stack[Task.stack.length - 1].context;
 }
 

--- a/index.js
+++ b/index.js
@@ -32,7 +32,8 @@ import {
 } from './api/plugins.js'
 import {
   getConfig,
-  getCourse
+  getCourse,
+  getComponents
 } from './api/helpers.js'
 import Journal from './lib/Journal.js'
 import CacheManager from './lib/CacheManager.js'
@@ -61,6 +62,7 @@ export {
   addPlugin,
   getConfig,
   getCourse,
+  getComponents,
   // environment objects
   Journal,
   CacheManager,


### PR DESCRIPTION
alternative to https://github.com/adaptlearning/adapt-migrations/pull/33

fixes #34 

### New
* Remove the need to pass the context `content` into the `getCourse()` and `getConfig()` helpers by getting it from the currently running Task
* Added `getComponents('accordion')` helper


### References

When in a Task's running state

Task instance this.context creation https://github.com/adaptlearning/adapt-migrations/blob/4b11897f3e8841820cc0f0a460022ef22c2feb4c/lib/Task.js#L127-L133

Task instance Task.stackUp https://github.com/adaptlearning/adapt-migrations/blob/4b11897f3e8841820cc0f0a460022ef22c2feb4c/lib/Task.js#L135

Task instance Task.stack stackDown https://github.com/adaptlearning/adapt-migrations/blob/4b11897f3e8841820cc0f0a460022ef22c2feb4c/lib/Task.js#L168

Task.stack API https://github.com/adaptlearning/adapt-migrations/blob/4b11897f3e8841820cc0f0a460022ef22c2feb4c/lib/Task.js#L230-L261