### PR TITLE
Fix: Test output (fixes #38)

### DIFF
--- a/api/tests.js
+++ b/api/tests.js
@@ -10,7 +10,7 @@ export function testSuccessWhere (description, {
   content
 }) {
   return deferOrRunWrap(() => {
-    logger.debug(`Tests -- testSuccessWhere ${description}`)
+    logger.info(`Test success where -- ${description}`)
     return new TaskTest({
       description,
       shouldRun: true,
@@ -27,7 +27,7 @@ export function testStopWhere (description, {
   content
 }) {
   return deferOrRunWrap(() => {
-    logger.debug(`Tests -- testStopWhere ${description}`)
+    logger.info(`Test stop where -- ${description}`)
     return new TaskTest({
       description,
       shouldStop: true,
@@ -45,7 +45,7 @@ export function testErrorWhere (description, {
   content
 }) {
   return deferOrRunWrap(() => {
-    logger.debug(`Tests -- testErrorWhere ${description}`)
+    logger.info(`Test error where -- ${description}`)
     return new TaskTest({
       description,
       shouldError: true,

--- a/lib/Task.js
+++ b/lib/Task.js
@@ -50,13 +50,13 @@ function prettyPrintJournal(journal, logger) {
   let lineIndex = 0
   const output = []
   while (lineIndex < lines.length) {
-    // collect lines with identical subject name values
+    // collect lines with identical subject name and id values
     const fromLineIndex = lineIndex
     let toLineIndex = lineIndex
     const line = lines[lineIndex]
     for (let i = lineIndex; i < lines.length; i++) {
       const nextLine = lines[i]
-      if (nextLine.name !== line.name) break
+      if (nextLine.name !== line.name || nextLine.id !== line.id) break
       toLineIndex = i
     }
     // print a grouped summary of the above lines with a single common subject line
@@ -66,6 +66,7 @@ function prettyPrintJournal(journal, logger) {
     output.push(`${subjectTable}\n${propertyChangeTable}\n`)
     lineIndex = toLineIndex + 1
   }
+  if (!output.length) return logger.info(`No changes where made`)
   logger.info(`Summary of changes:\n\n${output.join('\n')}`)
 }
 
@@ -343,17 +344,17 @@ export default class Task {
 
   static async runTests ({ cwd = process.cwd(), logger }) {
     for (const task of Task.clonedItems) {
-      logger.info(`Task -- Testing: ${task.description}`)
+      logger.info(`Testing -- ${task.description}`)
       for (const test of task.tests) {
         const {
           // description,
           shouldRun,
           shouldStop,
           shouldError,
-          fromPlugins,
-          originalFromPlugins,
-          toPlugins,
-          content
+          fromPlugins = [],
+          originalFromPlugins = [],
+          toPlugins = [],
+          content = []
         } = test()
         const journal = new Journal({
           logger,

--- a/lib/TaskTest.js
+++ b/lib/TaskTest.js
@@ -1,3 +1,5 @@
+import _ from 'lodash'
+
 export default class TaskTest {
   constructor ({
     description = '',
@@ -12,8 +14,8 @@ export default class TaskTest {
     this.shouldStop = shouldStop
     this.shouldRun = shouldRun
     this.shouldError = shouldError
-    this.fromPlugins = fromPlugins
-    this.toPlugins = toPlugins
-    this.content = content
+    this.fromPlugins = _.cloneDeep(fromPlugins)
+    this.toPlugins = _.cloneDeep(toPlugins)
+    this.content = _.cloneDeep(content)
   }
 }


### PR DESCRIPTION
### Fix
* Test execution label is clearer
* Summary of changes correctly prints for each unique_id when _type is missing from content
* Summary of changes reports no changes rather than a blank table
* Defaults were added for missing context elements
* Deep clone test content to prevent mutation of data passed by refence