### PR TITLE
Fix: Added color, fixed passed or failed status, differentiate summary by type (fixes #40)

### DIFF
--- a/api/tests.js
+++ b/api/tests.js
@@ -31,7 +31,6 @@ export function testStopWhere (description, {
     return new TaskTest({
       description,
       shouldStop: true,
-      shouldRun: false,
       fromPlugins,
       toPlugins,
       content

--- a/lib/Task.js
+++ b/lib/Task.js
@@ -56,7 +56,7 @@ function prettyPrintJournal(journal, logger) {
     const line = lines[lineIndex]
     for (let i = lineIndex; i < lines.length; i++) {
       const nextLine = lines[i]
-      if (nextLine.name !== line.name || nextLine.id !== line.id) break
+      if (nextLine.name !== line.name || nextLine.id !== line.id || nextLine.type !== line.type) break
       toLineIndex = i
     }
     // print a grouped summary of the above lines with a single common subject line

--- a/lib/Task.js
+++ b/lib/Task.js
@@ -371,10 +371,14 @@ export default class Task {
           hasRun
         } = await task.run({ cwd, journal, logger })
         const isPassed = (shouldError && hasErrored) ||
-          (shouldRun && hasRun) ||
-          (shouldRun === false && hasRun === false) ||
-          (shouldStop && hasStopped && !hasErrored)
-        logger.info(`> ${isPassed ? 'Passed' : 'Failed'}`)
+          (shouldStop && hasStopped && !hasErrored) ||
+          (shouldRun && hasRun && !hasErrored && !hasStopped) ||
+          (shouldRun === false && hasRun === false)
+        if (!isPassed) {
+          logger.info(chalk.red('> Failed'))
+        } else {
+          logger.info(chalk.greenBright('> Passed'))
+        }
         prettyPrintJournal(journal, logger)
       }
     }

--- a/lib/TaskTest.js
+++ b/lib/TaskTest.js
@@ -3,9 +3,9 @@ import _ from 'lodash'
 export default class TaskTest {
   constructor ({
     description = '',
-    shouldStop = true,
+    shouldStop = false,
     shouldRun = false,
-    shouldError = true,
+    shouldError = false,
     fromPlugins = [],
     toPlugins = [],
     content = []


### PR DESCRIPTION
fixes #40 
fixes #38 

### Fixes
* Testing pass/failed calculated more clearly with better task labels and conditions
* Color added to passed and failed status in the output
![image](https://github.com/user-attachments/assets/96c67a03-b851-47b7-a9b8-7620ce14016a)
* Summary of changes objects are differentiated by name, id and now also type, allowing test menus and pages to be separated
![image](https://github.com/user-attachments/assets/5d4d1c0a-0850-488c-a022-0872a23b8ab0)
