### PR TITLE
Fix: Cannot create proxy with a non-object as target or handler (fixes #46)

### DIFF
--- a/lib/Journal.js
+++ b/lib/Journal.js
@@ -134,7 +134,7 @@ export default class Journal {
               return target
             }
           }
-          if (Array.isArray(value) || typeof value === 'object') {
+          if (Array.isArray(value) || (typeof value === 'object' && value !== null)) {
             // Wrap an array or object in a new proxy, passing the appropriate key into the closure.
             return wrap(value, keys.concat([prop]))
           }


### PR DESCRIPTION
Fixes #46 

### Fix
* Check that value is not `null` before attempting to wrap the object in a new proxy