### PR TITLE
Update: Task updated to replace @@VERSION and @@RELEASE_VERSION from new migration scripts (fixes #48)

### DIFF
--- a/lib/Task.js
+++ b/lib/Task.js
@@ -5,6 +5,8 @@ import chalk from 'chalk'
 import TaskContext from './TaskContext.js'
 import Journal from '../lib/Journal.js'
 import { exec } from 'child_process'
+import pkgUp from 'pkg-up'
+import semver from 'semver'
 
 function makeTable(items, columnNames) {
   // calculate the max column widths for the items
@@ -277,9 +279,23 @@ export default class Task {
     toDelete.forEach(filePath => fs.rmSync(filePath))
     let i = 0
     for (const filePath of scripts) {
+      let fileContents = fs.readFileSync(filePath, 'utf8')
       const cachedPath = path.join(cachePath, `a${++i}.js`).replace(/\\/g, '/')
       Task.mapCacheToSource[cachedPath] = filePath.replace(/\\/g, '/')
-      fs.copyFileSync(filePath, cachedPath)
+      const replacements = ['@@CURRENT_VERSION', '@@RELEASE_VERSION']
+      if (replacements.some(item => fileContents.includes(item))) {
+        const packageJsonPath = await pkgUp({ cwd: filePath })
+        if (packageJsonPath) {
+          const packageJson = await fs.readJson(packageJsonPath)
+          const currentVersion = packageJson.version
+          const releaseVersion = semver.inc(currentVersion, 'patch')
+          fileContents = fileContents
+            .replace(/@@CURRENT_VERSION/g, currentVersion)
+            .replace(/@@RELEASE_VERSION/g, releaseVersion)
+          logger.info(`Task -- ${filePath} @@VERSION/@@RELEASE_VERSION replaced with ${currentVersion}/${releaseVersion}`)
+        }
+      }
+      fs.writeFileSync(cachedPath, fileContents, 'utf8')
     }
     fs.writeJsonSync(path.join(cachePath, 'package.json'), {
       name: 'migrations',


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)
To work with new automated release of migration scripts, allowing new scripts to use @@VERSION/@@RELEASE_VERSION which will then be populated on release, adapt-migration updated to do the same when testing/loading data. 

[//]: # (Link the PR to the original issue)
#48 

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Update
* Task updated to replace @@VERSION and @@RELEASE_VERSION from new migration scripts (fixes #48)


